### PR TITLE
Fix broken API url on dataset landing page

### DIFF
--- a/ckanext/aberdeen/templates/package/search.html
+++ b/ckanext/aberdeen/templates/package/search.html
@@ -49,7 +49,7 @@
     <div class="module-content">
       {% block package_search_results_api_inner %}
       <small>
-        {% set api_link = h.link_to(_('API'), 'api/action/status_show' %}
+        {% set api_link = h.link_to(_('API'), 'api/action/status_show') %}
         {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
         {% if g.dumps_url -%}
           {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}

--- a/ckanext/aberdeen/templates/package/search.html
+++ b/ckanext/aberdeen/templates/package/search.html
@@ -5,7 +5,7 @@
     <div class="module-content">                                                                                                              
       {% block package_search_results_api_inner %}                                                                                            
       <small>                                                                                                                                 
-        {% set api_link = h.link_to(_('API'), 'api/action/status_show') %}                                                                    
+        {% set api_link = h.link_to(_('API'), '/api/3/action/status_show') %}                                                                    
         {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}                      
         {% if g.dumps_url -%}                                                                                                                 
           {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}                                 
@@ -13,7 +13,7 @@
             You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.                
           {% endtrans %}                                                                                                                      
         {% else %}                                                                                                                            
-          {% trans %}                                                                                                                         
+           {% trans %}                                                                                                                         
             You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).                                               
           {% endtrans %}                                                                                                                      
         {%- endif %}                                                                                                                          

--- a/ckanext/aberdeen/templates/package/search.html
+++ b/ckanext/aberdeen/templates/package/search.html
@@ -1,81 +1,24 @@
-{% extends "page.html" %}
-{% import 'macros/form.html' as form %}
-
-{% block subtitle %}{{ _("Datasets") }}{% endblock %}
-
-{% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_('Datasets'), controller='package', action='search', highlight_actions = 'new index') }}</li>
-{% endblock %}
-
-{% block primary_content %}
-  <section class="module">
-    <div class="module-content">
-      {% block page_primary_action %}
-        {% if h.check_access('package_create') %}
-          <div class="page_primary_action">
-            {% link_for _('Add Dataset'), controller='package', action='new', class_='btn btn-primary', icon='plus-square' %}
-          </div>
-        {% endif %}
-      {% endblock %}
-      {% block form %}
-        {% set facets = {
-          'fields': c.fields_grouped,
-          'search': c.search_facets,
-          'titles': c.facet_titles,
-          'translated_fields': c.translated_fields,
-          'remove_field': c.remove_field }
-        %}
-        {% set sorting = [
-          (_('Relevance'), 'score desc, metadata_modified desc'),
-          (_('Name Ascending'), 'title_string asc'),
-          (_('Name Descending'), 'title_string desc'),
-          (_('Last Modified'), 'metadata_modified desc'),
-          (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
-        %}
-        {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
-      {% endblock %}
-      {% block package_search_results_list %}
-        {{ h.snippet('snippets/package_list.html', packages=c.page.items) }}
-      {% endblock %}
-    </div>
-
-    {% block page_pagination %}
-      {{ c.page.pager(q=c.q) }}
-    {% endblock %}
-  </section>
-
-  {% block package_search_results_api %}
-  <section class="module">
-    <div class="module-content">
-      {% block package_search_results_api_inner %}
-      <small>
-        {% set api_link = h.link_to(_('API'), 'api/action/status_show') %}
-        {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
-        {% if g.dumps_url -%}
-          {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}
-          {% trans %}
-            You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.
-          {% endtrans %}
-        {% else %}
-          {% trans %}
-            You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).
-          {% endtrans %}
-        {%- endif %}
-      </small>
-      {% endblock %}
-    </div>
-  </section>
-  {% endblock %}
-{% endblock %}
-
-
-{% block secondary_content %}
-<div class="filters">
-  <div>
-    {% for facet in c.facet_titles %}
-      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
-    {% endfor %}
-  </div>
-  <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
-</div>
+{% ckan_extends %}                                                                                                                            
+                                                                                                                                              
+{% block package_search_results_api %}                                                                                                        
+  <section class="module">                                                                                                                    
+    <div class="module-content">                                                                                                              
+      {% block package_search_results_api_inner %}                                                                                            
+      <small>                                                                                                                                 
+        {% set api_link = h.link_to(_('API'), 'api/action/status_show') %}                                                                    
+        {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}                      
+        {% if g.dumps_url -%}                                                                                                                 
+          {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}                                 
+          {% trans %}                                                                                                                         
+            You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.                
+          {% endtrans %}                                                                                                                      
+        {% else %}                                                                                                                            
+          {% trans %}                                                                                                                         
+            You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).                                               
+          {% endtrans %}                                                                                                                      
+        {%- endif %}                                                                                                                          
+      </small>                                                                                                                                
+      {% endblock %}                                                                                                                          
+    </div>                                                                                                                                    
+  </section>                                                                                                                                  
 {% endblock %}

--- a/ckanext/aberdeen/templates/package/search.html
+++ b/ckanext/aberdeen/templates/package/search.html
@@ -1,0 +1,81 @@
+{% extends "page.html" %}
+{% import 'macros/form.html' as form %}
+
+{% block subtitle %}{{ _("Datasets") }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li class="active">{{ h.nav_link(_('Datasets'), controller='package', action='search', highlight_actions = 'new index') }}</li>
+{% endblock %}
+
+{% block primary_content %}
+  <section class="module">
+    <div class="module-content">
+      {% block page_primary_action %}
+        {% if h.check_access('package_create') %}
+          <div class="page_primary_action">
+            {% link_for _('Add Dataset'), controller='package', action='new', class_='btn btn-primary', icon='plus-square' %}
+          </div>
+        {% endif %}
+      {% endblock %}
+      {% block form %}
+        {% set facets = {
+          'fields': c.fields_grouped,
+          'search': c.search_facets,
+          'titles': c.facet_titles,
+          'translated_fields': c.translated_fields,
+          'remove_field': c.remove_field }
+        %}
+        {% set sorting = [
+          (_('Relevance'), 'score desc, metadata_modified desc'),
+          (_('Name Ascending'), 'title_string asc'),
+          (_('Name Descending'), 'title_string desc'),
+          (_('Last Modified'), 'metadata_modified desc'),
+          (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+        %}
+        {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+      {% endblock %}
+      {% block package_search_results_list %}
+        {{ h.snippet('snippets/package_list.html', packages=c.page.items) }}
+      {% endblock %}
+    </div>
+
+    {% block page_pagination %}
+      {{ c.page.pager(q=c.q) }}
+    {% endblock %}
+  </section>
+
+  {% block package_search_results_api %}
+  <section class="module">
+    <div class="module-content">
+      {% block package_search_results_api_inner %}
+      <small>
+        {% set api_link = h.link_to(_('API'), 'api/action/status_show' %}
+        {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
+        {% if g.dumps_url -%}
+          {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}
+          {% trans %}
+            You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.
+          {% endtrans %}
+        {% else %}
+          {% trans %}
+            You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).
+          {% endtrans %}
+        {%- endif %}
+      </small>
+      {% endblock %}
+    </div>
+  </section>
+  {% endblock %}
+{% endblock %}
+
+
+{% block secondary_content %}
+<div class="filters">
+  <div>
+    {% for facet in c.facet_titles %}
+      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
+    {% endfor %}
+  </div>
+  <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+</div>
+{% endblock %}


### PR DESCRIPTION
Provides a temporary fix for https://gitlab.com/datopian/core/support/-/issues/206#note_321269873
 until the instance is upgraded to the latest version of ckan

## Problem
* In ckan 2.7 the link `/api/` doesnt work which works in 2.6 and 2.8.
* The `api` link on the `dataset` landing page redirects to random pages instead of redirecting to `/api/3` or to `/api/action/status_show`  if `/api/3` is 404.

## Solution implemented in PR

This PR adds a `/package/search.html` file in the templates folder of the extension which overrides the existing `search.html` template and  redirects the `api` link in the `dataset` landing page to `/api/action/status_show`
